### PR TITLE
[codex] Consolidate stale Jules draft PRs

### DIFF
--- a/Platform/Claude-Code-Prompt-Minimal.md
+++ b/Platform/Claude-Code-Prompt-Minimal.md
@@ -3,11 +3,11 @@
 ## KR
 
 ```text
-Use google-jules-control/SKILL.md as the local Jules guide. Prefer google-jules-control/scripts/jules_api.py for Jules operations. Prompts are strict-scope by default, and ambiguity should trigger a clarifying question instead of broader work. Start with doctor, resolve owner/repo if needed, and summarize outputs briefly.
+Use google-jules-control/SKILL.md as the local Jules guide. Prefer google-jules-control/scripts/jules_api.py for Jules operations. Prompts are strict-scope by default, and ambiguity should trigger a clarifying question instead of broader work. Start with doctor, resolve owner/repo if needed, and summarize outputs briefly. Before approving a Jules plan, run a scope review against the original task, scope notes, non-goals, and strict-scope rules; do not approve scope drift by default.
 ```
 
 ## EN
 
 ```text
-Use google-jules-control/SKILL.md as the local Jules guide. Prefer google-jules-control/scripts/jules_api.py for Jules operations. Prompts are strict-scope by default, and ambiguity should trigger a clarifying question instead of broader work. Start with doctor, resolve owner/repo if needed, and summarize outputs briefly.
+Use google-jules-control/SKILL.md as the local Jules guide. Prefer google-jules-control/scripts/jules_api.py for Jules operations. Prompts are strict-scope by default, and ambiguity should trigger a clarifying question instead of broader work. Start with doctor, resolve owner/repo if needed, and summarize outputs briefly. Before approving a Jules plan, run a scope review against the original task, scope notes, non-goals, and strict-scope rules; do not approve scope drift by default.
 ```

--- a/Platform/Claude-Code-Prompt-Strict-Ops.md
+++ b/Platform/Claude-Code-Prompt-Strict-Ops.md
@@ -13,6 +13,7 @@ Rules:
 - Prompts sent through `create-session`, `send-message`, `resume`, and `request-pr-rework` are strict-scope by default.
 - If the task is ambiguous or appears to require out-of-scope work, ask a clarifying question instead of broadening the task.
 - Use `--scope-note` and `--non-goal` when extra boundaries matter.
+- Before approving a Jules plan, compare it against the original task, scope notes, non-goals, and strict-scope rules; do not approve scope drift by default.
 - Use `summary`, `cleanup-report --markdown`, `close-ready-report --markdown`, and `notify-close-plan --markdown` for user-facing communication.
 - Check `gh-auth-check --compact` before merge-aware cleanup.
 - Never close, cancel, or delete a Jules session without explicit user confirmation.
@@ -39,6 +40,7 @@ Rules:
 - Prompts sent through `create-session`, `send-message`, `resume`, and `request-pr-rework` are strict-scope by default.
 - If the task is ambiguous or appears to require out-of-scope work, ask a clarifying question instead of broadening the task.
 - Use `--scope-note` and `--non-goal` when extra boundaries matter.
+- Before approving a Jules plan, compare it against the original task, scope notes, non-goals, and strict-scope rules; do not approve scope drift by default.
 - Use `summary`, `cleanup-report --markdown`, `close-ready-report --markdown`, and `notify-close-plan --markdown` for user-facing communication.
 - Check `gh-auth-check --compact` before merge-aware cleanup.
 - Never close, cancel, or delete a Jules session without explicit user confirmation.

--- a/Platform/Claude-Code-Prompt-Strict-Ops.md
+++ b/Platform/Claude-Code-Prompt-Strict-Ops.md
@@ -15,7 +15,7 @@ Rules:
 - Use `--scope-note` and `--non-goal` when extra boundaries matter.
 - Use `summary`, `cleanup-report --markdown`, `close-ready-report --markdown`, and `notify-close-plan --markdown` for user-facing communication.
 - Check `gh-auth-check --compact` before merge-aware cleanup.
-- Never delete or close a Jules session without explicit user confirmation.
+- Never close, cancel, or delete a Jules session without explicit user confirmation.
 - Summarize long JSON outputs into concise operational messages.
 
 Sequence:
@@ -41,7 +41,7 @@ Rules:
 - Use `--scope-note` and `--non-goal` when extra boundaries matter.
 - Use `summary`, `cleanup-report --markdown`, `close-ready-report --markdown`, and `notify-close-plan --markdown` for user-facing communication.
 - Check `gh-auth-check --compact` before merge-aware cleanup.
-- Never delete or close a Jules session without explicit user confirmation.
+- Never close, cancel, or delete a Jules session without explicit user confirmation.
 - Summarize long JSON outputs into concise operational messages.
 
 Sequence:

--- a/Platform/Claude-Code-Prompt.md
+++ b/Platform/Claude-Code-Prompt.md
@@ -15,6 +15,7 @@ When working with Google Jules:
 - Prompts sent through `create-session`, `send-message`, `resume`, and `request-pr-rework` are wrapped with a strict-scope contract by default.
 - If the task is ambiguous or appears to require out-of-scope work, ask a clarifying question instead of broadening the task.
 - Use `--scope-note` and `--non-goal` when you need extra task boundaries.
+- Before approving a Jules plan, compare it against the original task, scope notes, non-goals, and strict-scope rules; do not approve scope drift by default.
 - Use `summary`, `cleanup-report`, `close-ready-report`, and `notify-close-plan --markdown` to keep users informed.
 - Never close, cancel, or delete a Jules session without explicit user confirmation.
 - Before merge-aware cleanup actions, verify GitHub auth with `gh-auth-check --compact`.
@@ -43,6 +44,7 @@ When working with Google Jules:
 - Prompts sent through `create-session`, `send-message`, `resume`, and `request-pr-rework` are wrapped with a strict-scope contract by default.
 - If the task is ambiguous or appears to require out-of-scope work, ask a clarifying question instead of broadening the task.
 - Use `--scope-note` and `--non-goal` when you need extra task boundaries.
+- Before approving a Jules plan, compare it against the original task, scope notes, non-goals, and strict-scope rules; do not approve scope drift by default.
 - Use `summary`, `cleanup-report`, `close-ready-report`, and `notify-close-plan --markdown` to keep users informed.
 - Never close, cancel, or delete a Jules session without explicit user confirmation.
 - Before merge-aware cleanup actions, verify GitHub auth with `gh-auth-check --compact`.

--- a/Platform/Claude-Code-Prompt.md
+++ b/Platform/Claude-Code-Prompt.md
@@ -16,7 +16,7 @@ When working with Google Jules:
 - If the task is ambiguous or appears to require out-of-scope work, ask a clarifying question instead of broadening the task.
 - Use `--scope-note` and `--non-goal` when you need extra task boundaries.
 - Use `summary`, `cleanup-report`, `close-ready-report`, and `notify-close-plan --markdown` to keep users informed.
-- Never close or delete a Jules session without explicit user confirmation.
+- Never close, cancel, or delete a Jules session without explicit user confirmation.
 - Before merge-aware cleanup actions, verify GitHub auth with `gh-auth-check --compact`.
 - Summarize long JSON outputs into concise user-facing updates.
 
@@ -44,7 +44,7 @@ When working with Google Jules:
 - If the task is ambiguous or appears to require out-of-scope work, ask a clarifying question instead of broadening the task.
 - Use `--scope-note` and `--non-goal` when you need extra task boundaries.
 - Use `summary`, `cleanup-report`, `close-ready-report`, and `notify-close-plan --markdown` to keep users informed.
-- Never close or delete a Jules session without explicit user confirmation.
+- Never close, cancel, or delete a Jules session without explicit user confirmation.
 - Before merge-aware cleanup actions, verify GitHub auth with `gh-auth-check --compact`.
 - Summarize long JSON outputs into concise user-facing updates.
 

--- a/Platform/Claude-Code-Prompt.md
+++ b/Platform/Claude-Code-Prompt.md
@@ -16,7 +16,7 @@ When working with Google Jules:
 - If the task is ambiguous or appears to require out-of-scope work, ask a clarifying question instead of broadening the task.
 - Use `--scope-note` and `--non-goal` when you need extra task boundaries.
 - Before approving a Jules plan, compare it against the original task, scope notes, non-goals, and strict-scope rules; do not approve scope drift by default.
-- Use `summary`, `cleanup-report`, `close-ready-report`, and `notify-close-plan --markdown` to keep users informed.
+- Use `summary`, `cleanup-report --markdown`, `close-ready-report --markdown`, and `notify-close-plan --markdown` to keep users informed.
 - Never close, cancel, or delete a Jules session without explicit user confirmation.
 - Before merge-aware cleanup actions, verify GitHub auth with `gh-auth-check --compact`.
 - Summarize long JSON outputs into concise user-facing updates.
@@ -45,7 +45,7 @@ When working with Google Jules:
 - If the task is ambiguous or appears to require out-of-scope work, ask a clarifying question instead of broadening the task.
 - Use `--scope-note` and `--non-goal` when you need extra task boundaries.
 - Before approving a Jules plan, compare it against the original task, scope notes, non-goals, and strict-scope rules; do not approve scope drift by default.
-- Use `summary`, `cleanup-report`, `close-ready-report`, and `notify-close-plan --markdown` to keep users informed.
+- Use `summary`, `cleanup-report --markdown`, `close-ready-report --markdown`, and `notify-close-plan --markdown` to keep users informed.
 - Never close, cancel, or delete a Jules session without explicit user confirmation.
 - Before merge-aware cleanup actions, verify GitHub auth with `gh-auth-check --compact`.
 - Summarize long JSON outputs into concise user-facing updates.

--- a/Platform/Claude-Code.md
+++ b/Platform/Claude-Code.md
@@ -24,6 +24,16 @@ Claude Code에서는 이 저장소의 핵심 자산을 “프로젝트 문서 + 
 Use the local project guide at google-jules-control/SKILL.md. Prefer the bundled Jules control script for all Jules operations. Start with doctor, resolve the repo to a Jules source, then continue with session creation or reporting.
 ```
 
+### Setup checks와 완료 기준
+
+- Claude Code 프로젝트 문서나 프롬프트가 `google-jules-control/SKILL.md`를 참조하는지 확인
+- Claude Code shell에서 `doctor --compact`가 `.env`와 `JULES_API_KEY`를 읽는지 확인. 통과 기준은 `dotenv=yes api_key=yes api_ready=yes`
+- long-running 명령은 중간 상태를 `summary`로 요약하고 필요하면 `wait`를 사용
+- 긴 JSON 출력은 사용자에게 그대로 붙이지 말고 핵심 상태만 요약
+- 사용자 검토에는 `--markdown`, 파일 보관이나 자동화에는 `export --output` 사용
+
+완료 기준: Claude Code가 이 문서와 `SKILL.md`만 보고 source 해석, 세션 생성, 세션 요약, markdown/JSON 출력 선택을 수행할 수 있어야 합니다.
+
 ## EN
 
 ### Adaptation Model
@@ -47,3 +57,13 @@ In Claude Code, the safest migration model is to treat this repository as a comb
 ```text
 Use the local project guide at google-jules-control/SKILL.md. Prefer the bundled Jules control script for all Jules operations. Start with doctor, resolve the repo to a Jules source, then continue with session creation or reporting.
 ```
+
+### Setup Checks And Done Criteria
+
+- Confirm Claude Code project docs or prompts point to `google-jules-control/SKILL.md`
+- Confirm Claude Code shell execution can read `.env` and `JULES_API_KEY` with `doctor --compact`; pass only when it includes `dotenv=yes api_key=yes api_ready=yes`
+- Summarize intermediate state for long-running commands with `summary`, and use `wait` when appropriate
+- Do not paste long raw JSON to users; summarize the operational state first
+- Use `--markdown` for human review and `export --output` for archived or automated JSON
+
+Done criteria: Claude Code can use only this guide and `SKILL.md` to resolve a source, create a session, summarize it, and choose markdown versus JSON output correctly.

--- a/Platform/Codex-Prompt-Minimal.md
+++ b/Platform/Codex-Prompt-Minimal.md
@@ -3,11 +3,11 @@
 ## KR
 
 ```text
-Use google-jules-control/SKILL.md as the Jules operating guide. Use google-jules-control/scripts/jules_api.py for Jules actions. Prompts are strict-scope by default, and ambiguity should trigger a clarifying question instead of broader work. Start with doctor, resolve owner/repo with repo-to-source if needed, and summarize results concisely.
+Use google-jules-control/SKILL.md as the Jules operating guide. Use google-jules-control/scripts/jules_api.py for Jules actions. Prompts are strict-scope by default, and ambiguity should trigger a clarifying question instead of broader work. Start with doctor, resolve owner/repo with repo-to-source if needed, and summarize results concisely. Before approving a Jules plan, run a scope review against the original task, scope notes, non-goals, and strict-scope rules; do not approve scope drift by default.
 ```
 
 ## EN
 
 ```text
-Use google-jules-control/SKILL.md as the Jules operating guide. Use google-jules-control/scripts/jules_api.py for Jules actions. Prompts are strict-scope by default, and ambiguity should trigger a clarifying question instead of broader work. Start with doctor, resolve owner/repo with repo-to-source if needed, and summarize results concisely.
+Use google-jules-control/SKILL.md as the Jules operating guide. Use google-jules-control/scripts/jules_api.py for Jules actions. Prompts are strict-scope by default, and ambiguity should trigger a clarifying question instead of broader work. Start with doctor, resolve owner/repo with repo-to-source if needed, and summarize results concisely. Before approving a Jules plan, run a scope review against the original task, scope notes, non-goals, and strict-scope rules; do not approve scope drift by default.
 ```

--- a/Platform/Codex-Prompt-Strict-Ops.md
+++ b/Platform/Codex-Prompt-Strict-Ops.md
@@ -13,6 +13,7 @@ Rules:
 - Prompts sent through `create-session`, `send-message`, `resume`, and `request-pr-rework` are strict-scope by default.
 - If the task is ambiguous or appears to require out-of-scope work, ask a clarifying question instead of broadening the task.
 - Use `--scope-note` and `--non-goal` when extra boundaries matter.
+- Before approving a Jules plan, compare it against the original task, scope notes, non-goals, and strict-scope rules; do not approve scope drift by default.
 - Before merge-aware reporting or cleanup, run `gh-auth-check --compact`.
 - Use `summary`, `cleanup-report --markdown`, `close-ready-report --markdown`, and `notify-close-plan --markdown` for user-facing updates.
 - Do not close, cancel, or delete a Jules session without explicit user confirmation.
@@ -39,6 +40,7 @@ Rules:
 - Prompts sent through `create-session`, `send-message`, `resume`, and `request-pr-rework` are strict-scope by default.
 - If the task is ambiguous or appears to require out-of-scope work, ask a clarifying question instead of broadening the task.
 - Use `--scope-note` and `--non-goal` when extra boundaries matter.
+- Before approving a Jules plan, compare it against the original task, scope notes, non-goals, and strict-scope rules; do not approve scope drift by default.
 - Before merge-aware reporting or cleanup, run `gh-auth-check --compact`.
 - Use `summary`, `cleanup-report --markdown`, `close-ready-report --markdown`, and `notify-close-plan --markdown` for user-facing updates.
 - Do not close, cancel, or delete a Jules session without explicit user confirmation.

--- a/Platform/Codex-Prompt.md
+++ b/Platform/Codex-Prompt.md
@@ -15,6 +15,7 @@ When handling Jules-related tasks:
 - Prompts sent through `create-session`, `send-message`, `resume`, and `request-pr-rework` are wrapped with a strict-scope contract by default.
 - If the task is ambiguous or appears to require out-of-scope work, ask a clarifying question instead of broadening the task.
 - Use `--scope-note` and `--non-goal` when you need extra task boundaries.
+- Before approving a Jules plan, compare it against the original task, scope notes, non-goals, and strict-scope rules; do not approve scope drift by default.
 - Use `summary`, `cleanup-report --markdown`, `close-ready-report --markdown`, and `notify-close-plan --markdown` for user-facing updates.
 - Before merge-aware cleanup, run `gh-auth-check --compact`.
 - Never close, cancel, or delete a Jules session without explicit user confirmation.
@@ -43,6 +44,7 @@ When handling Jules-related tasks:
 - Prompts sent through `create-session`, `send-message`, `resume`, and `request-pr-rework` are wrapped with a strict-scope contract by default.
 - If the task is ambiguous or appears to require out-of-scope work, ask a clarifying question instead of broadening the task.
 - Use `--scope-note` and `--non-goal` when you need extra task boundaries.
+- Before approving a Jules plan, compare it against the original task, scope notes, non-goals, and strict-scope rules; do not approve scope drift by default.
 - Use `summary`, `cleanup-report --markdown`, `close-ready-report --markdown`, and `notify-close-plan --markdown` for user-facing updates.
 - Before merge-aware cleanup, run `gh-auth-check --compact`.
 - Never close, cancel, or delete a Jules session without explicit user confirmation.

--- a/Platform/Codex.md
+++ b/Platform/Codex.md
@@ -28,6 +28,16 @@ python3 google-jules-control/scripts/jules_api.py create-session ...
 python3 google-jules-control/scripts/jules_api.py summary --session sessions/SESSION_ID
 ```
 
+### Setup checks와 완료 기준
+
+- `$google-jules-control` 또는 `google-jules-control/SKILL.md`가 Codex 컨텍스트에서 발견되는지 확인
+- Codex shell에서 `doctor --compact`가 `.env`와 `JULES_API_KEY`를 읽는지 확인. 통과 기준은 `dotenv=yes api_key=yes api_ready=yes`
+- long-running 세션은 `wait` 또는 반복 `summary`로 상태를 갱신
+- 사용자 보고에는 `cleanup-report --markdown`, `close-ready-report --markdown`, `notify-close-plan --markdown` 사용
+- 구조화된 결과가 필요할 때만 JSON 원문이나 `export --output` 사용
+
+완료 기준: Codex가 source 해석, 세션 생성, 세션 요약, markdown 보고를 사용자에게 간결하게 전달하고, JSON 원문이나 `export --output`은 구조화/보관 용도로만 사용할 수 있어야 합니다.
+
 ## EN
 
 ### Current Reference Platform
@@ -55,3 +65,13 @@ python3 google-jules-control/scripts/jules_api.py repo-to-source --repo owner/re
 python3 google-jules-control/scripts/jules_api.py create-session ...
 python3 google-jules-control/scripts/jules_api.py summary --session sessions/SESSION_ID
 ```
+
+### Setup Checks And Done Criteria
+
+- Confirm `$google-jules-control` or `google-jules-control/SKILL.md` is discoverable in the Codex context
+- Confirm Codex shell execution can read `.env` and `JULES_API_KEY` with `doctor --compact`; pass only when it includes `dotenv=yes api_key=yes api_ready=yes`
+- Monitor long-running sessions with `wait` or repeated `summary`
+- Use `cleanup-report --markdown`, `close-ready-report --markdown`, and `notify-close-plan --markdown` for user-facing reports
+- Use raw JSON or `export --output` only when structured output is needed
+
+Done criteria: Codex can resolve a source, create a session, summarize the session, present markdown reports concisely, and reserve raw JSON or `export --output` for structured or archival use.

--- a/Platform/Google-Antigravity-Prompt-Minimal.md
+++ b/Platform/Google-Antigravity-Prompt-Minimal.md
@@ -3,11 +3,11 @@
 ## KR
 
 ```text
-Read google-jules-control/SKILL.md first. Use google-jules-control/scripts/jules_api.py for Jules operations. Keep prompts strict-scope by default, ask a clarifying question when the task is ambiguous, start with doctor, resolve owner/repo if needed, and keep user-facing updates short.
+Read google-jules-control/SKILL.md first. Use google-jules-control/scripts/jules_api.py for Jules operations. Keep prompts strict-scope by default, ask a clarifying question when the task is ambiguous, start with doctor, resolve owner/repo if needed, and keep user-facing updates short. Before approving a Jules plan, run a scope review against the original task, scope notes, non-goals, and strict-scope rules; do not approve scope drift by default.
 ```
 
 ## EN
 
 ```text
-Read google-jules-control/SKILL.md first. Use google-jules-control/scripts/jules_api.py for Jules operations. Keep prompts strict-scope by default, ask a clarifying question when the task is ambiguous, start with doctor, resolve owner/repo if needed, and keep user-facing updates short.
+Read google-jules-control/SKILL.md first. Use google-jules-control/scripts/jules_api.py for Jules operations. Keep prompts strict-scope by default, ask a clarifying question when the task is ambiguous, start with doctor, resolve owner/repo if needed, and keep user-facing updates short. Before approving a Jules plan, run a scope review against the original task, scope notes, non-goals, and strict-scope rules; do not approve scope drift by default.
 ```

--- a/Platform/Google-Antigravity-Prompt-Strict-Ops.md
+++ b/Platform/Google-Antigravity-Prompt-Strict-Ops.md
@@ -13,6 +13,7 @@ Rules:
 - Prompts sent through `create-session`, `send-message`, `resume`, and `request-pr-rework` are strict-scope by default.
 - If the task is ambiguous or appears to require out-of-scope work, ask a clarifying question instead of broadening the task.
 - Use `--scope-note` and `--non-goal` when extra boundaries matter.
+- Before approving a Jules plan, compare it against the original task, scope notes, non-goals, and strict-scope rules; do not approve scope drift by default.
 - Prefer `summary`, `cleanup-report --markdown`, `close-ready-report --markdown`, and `notify-close-plan --markdown` for human review.
 - Run `gh-auth-check --compact` before merge-aware reporting or cleanup.
 - Require explicit user confirmation before any delete-style command or `close-merged-session`.
@@ -39,6 +40,7 @@ Rules:
 - Prompts sent through `create-session`, `send-message`, `resume`, and `request-pr-rework` are strict-scope by default.
 - If the task is ambiguous or appears to require out-of-scope work, ask a clarifying question instead of broadening the task.
 - Use `--scope-note` and `--non-goal` when extra boundaries matter.
+- Before approving a Jules plan, compare it against the original task, scope notes, non-goals, and strict-scope rules; do not approve scope drift by default.
 - Prefer `summary`, `cleanup-report --markdown`, `close-ready-report --markdown`, and `notify-close-plan --markdown` for human review.
 - Run `gh-auth-check --compact` before merge-aware reporting or cleanup.
 - Require explicit user confirmation before any delete-style command or `close-merged-session`.

--- a/Platform/Google-Antigravity-Prompt.md
+++ b/Platform/Google-Antigravity-Prompt.md
@@ -16,6 +16,7 @@ Operational rules:
 - Prompts sent through `create-session`, `send-message`, `resume`, and `request-pr-rework` are wrapped with a strict-scope contract by default.
 - If the task is ambiguous or appears to require out-of-scope work, ask a clarifying question instead of broadening the task.
 - Use `--scope-note` and `--non-goal` when you need extra task boundaries.
+- Before approving a Jules plan, compare it against the original task, scope notes, non-goals, and strict-scope rules; do not approve scope drift by default.
 - Prefer `summary`, `cleanup-report --markdown`, and `close-ready-report --markdown` for human-readable updates.
 - Use `notify-close-plan --markdown` when preparing a user confirmation message before closure.
 - Require explicit user confirmation before running `close-merged-session` or any delete-style command.
@@ -46,6 +47,7 @@ Operational rules:
 - Prompts sent through `create-session`, `send-message`, `resume`, and `request-pr-rework` are wrapped with a strict-scope contract by default.
 - If the task is ambiguous or appears to require out-of-scope work, ask a clarifying question instead of broadening the task.
 - Use `--scope-note` and `--non-goal` when you need extra task boundaries.
+- Before approving a Jules plan, compare it against the original task, scope notes, non-goals, and strict-scope rules; do not approve scope drift by default.
 - Prefer `summary`, `cleanup-report --markdown`, and `close-ready-report --markdown` for human-readable updates.
 - Use `notify-close-plan --markdown` when preparing a user confirmation message before closure.
 - Require explicit user confirmation before running `close-merged-session` or any delete-style command.

--- a/Platform/Google-Antigravity.md
+++ b/Platform/Google-Antigravity.md
@@ -24,6 +24,16 @@ Google Antigravity에서는 이 저장소를 “에이전트가 읽는 운영 �
 Read google-jules-control/SKILL.md first. Use the bundled Jules control script for session management, reporting, and cleanup. Prefer markdown reports for human review and require explicit confirmation before any session deletion.
 ```
 
+### Setup checks와 완료 기준
+
+- Antigravity 작업공간에 `google-jules-control/SKILL.md`와 실행 스크립트 경로가 노출되는지 확인
+- shell 실행 컨텍스트에서 `doctor --compact`가 `.env`와 `JULES_API_KEY`를 읽는지 확인. 통과 기준은 `dotenv=yes api_key=yes api_ready=yes`
+- long-running 세션은 `wait` 또는 반복 `summary`를 카드/패널에 갱신 가능한 형태로 표시
+- 카드형 UI에는 `--markdown` 보고서를 우선 사용
+- 자동화나 디버깅에는 JSON 출력 또는 `export --output`을 별도로 보관
+
+완료 기준: Antigravity가 source 해석, 세션 생성, 세션 상태 갱신, markdown 보고, JSON 또는 `export --output` 보관을 구분해서 처리할 수 있어야 합니다.
+
 ## EN
 
 ### Adaptation Model
@@ -47,3 +57,13 @@ For Google Antigravity, this repository works best as an agent-readable operatin
 ```text
 Read google-jules-control/SKILL.md first. Use the bundled Jules control script for session management, reporting, and cleanup. Prefer markdown reports for human review and require explicit confirmation before any session deletion.
 ```
+
+### Setup Checks And Done Criteria
+
+- Confirm Antigravity workspace exposes `google-jules-control/SKILL.md` and the execution script path
+- Confirm the shell execution context can read `.env` and `JULES_API_KEY` with `doctor --compact`; pass only when it includes `dotenv=yes api_key=yes api_ready=yes`
+- Show long-running sessions through `wait` or repeated `summary` in a card/panel-friendly way
+- Prefer `--markdown` reports for card-style UI review
+- Keep JSON output or `export --output` separate for automation or debugging
+
+Done criteria: Antigravity can resolve a source, create a session, update session status, render markdown reports, and keep JSON or `export --output` separate for archival/debugging.

--- a/Platform/Migration-Guide.md
+++ b/Platform/Migration-Guide.md
@@ -52,7 +52,7 @@ Use this document as the shared baseline when adapting the `google-jules-control
 - Keep `google-jules-control/scripts/jules_api.py` as the single source of truth for Jules API control
 - Keep `.env` and `JULES_API_KEY` as the primary auth path
 - Keep merge checks based on `gh`
-- Keep session closure behind explicit user confirmation
+- Keep session close, cancel, and delete actions behind explicit user confirmation
 
 ### Platform Migration Checkpoints
 
@@ -68,7 +68,7 @@ Use this document as the shared baseline when adapting the `google-jules-control
    - support for absolute-path links
    - markdown rendering behavior
 4. Operational safety
-   - user confirmation before deletion
+   - user confirmation before close, cancel, or delete
    - merge-state verification
    - protection against leaking `.env`
 

--- a/Platform/README.md
+++ b/Platform/README.md
@@ -26,6 +26,20 @@
 - 프롬프트, 도구 호출, 인증, 작업 흐름 차이를 정리하기
 - 동일한 Jules 제어 운영 절차를 다른 에이전트에서도 재현하기
 
+공통 setup checks:
+
+- 스킬 등록 또는 프로젝트 문서 주입 경로가 명확한지 확인
+- `.env`의 `JULES_API_KEY`를 해당 플랫폼의 실행 컨텍스트에서 읽을 수 있는지 `doctor --compact`로 확인. 통과 기준은 `dotenv=yes api_key=yes api_ready=yes`
+- `repo-to-source --repo owner/repo --compact` 결과를 다음 명령에 넘길 수 있는지 확인
+- long-running 작업은 `wait` 또는 반복 `summary`로 갱신 상태를 보여줄 수 있는지 확인
+- 사람 검토용 출력은 `--markdown`, 자동화용 출력은 JSON 또는 `export --output`으로 처리할 수 있는지 확인
+
+완료 기준:
+
+- 플랫폼 가이드만 보고 `doctor`, `repo-to-source`, `create-session`, `summary` 순서를 재현할 수 있음
+- `.env`나 JSON 원문을 사용자에게 노출하지 않고 필요한 상태만 요약할 수 있음
+- 삭제, close, cancel 같은 destructive action 전에 사용자 확인을 요구함
+
 ## EN
 
 This folder contains platform adaptation guides for using the `google-jules-control` workflow beyond Codex.
@@ -51,3 +65,17 @@ Goals:
 - Translate this repository's operating model into platform-specific terms
 - Clarify prompt, tool, auth, and workflow differences
 - Preserve the same Jules control workflow across multiple agent environments
+
+Shared setup checks:
+
+- Confirm the skill registration or project-document injection path is explicit
+- Confirm the platform execution context can read `JULES_API_KEY` from `.env` with `doctor --compact`; pass only when it includes `dotenv=yes api_key=yes api_ready=yes`
+- Confirm `repo-to-source --repo owner/repo --compact` output can be handed to the next command
+- Confirm long-running work can be monitored with `wait` or repeated `summary`
+- Confirm human review uses `--markdown`, while automation uses JSON or `export --output`
+
+Done criteria:
+
+- A user can reproduce the `doctor`, `repo-to-source`, `create-session`, `summary` sequence from the platform guide alone
+- The platform can summarize status without exposing `.env` contents or dumping raw JSON by default
+- Destructive actions such as delete, close, or cancel require user confirmation first

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ google-jules-skill/
 python3 google-jules-control/scripts/jules_api.py doctor --compact
 ```
 
+키가 실제 API 인증까지 통과하는지 확인하려면 아래처럼 검증 probe를 추가합니다.
+Add the validation probe when you need to confirm that the key authenticates with the API.
+
+```bash
+python3 google-jules-control/scripts/jules_api.py doctor --compact --validate-api
+```
+
 4. 저장소를 Jules source로 해석합니다.  
    Resolve a repository to a Jules source.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ This repository contains a skill for controlling Google Jules from an LLM agent.
   Google Jules REST API와 Jules CLI를 통해 세션 생성, 상태 조회, 후속 지시, 정리 리포트, merge 확인, 세션 종료를 수행합니다.  
   Controls Google Jules sessions through the Jules REST API and Jules CLI, including session creation, status checks, follow-up instructions, cleanup reports, merge checks, and session closure.
 
+## 설치 및 등록 / Installation And Registration
+
+- 스킬을 등록하려면 `SKILL.md`가 들어 있는 `google-jules-control/` 폴더를 에이전트의 skills 디렉터리에 둡니다. Codex에 수동으로 로컬 스킬을 설치할 때는 보통 `${CODEX_HOME:-$HOME/.codex}/skills/google-jules-control` 위치를 사용합니다.
+  To register the skill, place the `google-jules-control/` folder that contains `SKILL.md` in the agent skills directory. For manual local Codex skill installs, this usually means `${CODEX_HOME:-$HOME/.codex}/skills/google-jules-control`.
+- `google-jules-control/agents/openai.yaml`은 이 manifest를 지원하는 OpenAI 계열 에이전트가 표시 이름, 짧은 설명, 기본 프롬프트를 읽을 때 쓰는 파일입니다. Python helper가 실행 중에 읽는 설정 파일은 아닙니다.
+  `google-jules-control/agents/openai.yaml` is for OpenAI-style agents that support this manifest and need the display name, short description, and default prompt. The Python helper does not read it at runtime.
+- 등록 확인은 새 에이전트 컨텍스트에서 `$google-jules-control`을 호출해 `doctor --compact` 실행을 요청하는 방식으로 확인합니다. 인식되지 않으면 설치 위치와 `SKILL.md`의 `name: google-jules-control`을 확인합니다.
+  Verify discoverability by invoking `$google-jules-control` in a fresh agent context and asking it to run `doctor --compact`. If it is not recognized, check the install location and the `name: google-jules-control` front matter in `SKILL.md`.
+
 ## 저장소 구조 / Repository Layout
 
 ```text
@@ -38,11 +47,23 @@ google-jules-skill/
 
 ## 빠른 시작 / Quick Start
 
-1. `google-jules-control/.env.example`를 바탕으로 `.env`를 준비합니다.  
-   Create a `.env` file from `google-jules-control/.env.example`.
-2. `.env`에 `JULES_API_KEY`를 넣습니다.  
-   Put your `JULES_API_KEY` into `.env`.
-3. 준비 상태를 확인합니다.  
+1. 이 스킬 저장소 clone의 루트에서 시작합니다.
+   Start from the root of this skill repository clone.
+
+```bash
+cd google-jules-skill
+```
+
+2. `google-jules-control/.env.example`를 `google-jules-control/.env`로 복사합니다.
+   Copy `google-jules-control/.env.example` to `google-jules-control/.env`.
+
+```bash
+cp google-jules-control/.env.example google-jules-control/.env
+```
+
+3. `.env`에 `JULES_API_KEY`를 넣습니다. 저장소 루트 `.env`가 이미 있으면 스크립트가 그 파일을 먼저 읽으므로, 그 파일에도 `JULES_API_KEY`가 있어야 합니다.
+   Put your `JULES_API_KEY` into `.env`. If a repository-root `.env` already exists, the script reads that file first, so it must also contain `JULES_API_KEY`.
+4. 준비 상태를 확인합니다.
    Run a readiness check.
 
 ```bash
@@ -56,14 +77,16 @@ Add the validation probe when you need to confirm that the key authenticates wit
 python3 google-jules-control/scripts/jules_api.py doctor --compact --validate-api
 ```
 
-4. 저장소를 Jules source로 해석합니다.  
+5. 저장소를 Jules source로 해석합니다.
    Resolve a repository to a Jules source.
 
 ```bash
 python3 google-jules-control/scripts/jules_api.py repo-to-source --repo owner/repo --compact
 ```
 
-5. 자세한 사용법은 `google-jules-control/SKILL.md`를 참고합니다.  
+6. 복사해서 따라갈 수 있는 smoke test는 `docs/setup-and-test.md`를 참고합니다.
+   For a copy-paste smoke test, read `docs/setup-and-test.md`.
+7. 자세한 사용법은 `google-jules-control/SKILL.md`를 참고합니다.
    Read `google-jules-control/SKILL.md` for the full operating guide.
 
 ## 가이드 / Guides

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -13,13 +13,74 @@ Use this checklist before sharing or publishing the skill.
 - 저장소 루트 `.gitignore`에 `.env`가 포함되는지 확인 / Confirm the repository-root `.gitignore` excludes `.env`
 - 저장소 루트와 스킬 폴더에 실제 시크릿이 추적되지 않는지 확인 / Ensure no real secrets are tracked in the repository root or skill folder
 
-## 검증 / Validation
+## Fresh Checkout Validation / 새 checkout 검증
+
+아래 명령은 이 저장소 루트의 fresh checkout에서 그대로 실행 가능해야 합니다. 실제 Jules 계정이나 target repository가 필요한 검증은 다음 섹션으로 분리합니다.
+The commands below must run as-is from a fresh checkout of this repository root. Checks that require a real Jules account or target repository are separated into the next section.
 
 ```bash
 python3 -m py_compile google-jules-control/scripts/jules_api.py
 python3 -m unittest discover -s tests
-python3 /path/to/quick_validate.py google-jules-control
+
+python3 google-jules-control/scripts/jules_api.py --help >/tmp/google-jules-skill-help.txt
+python3 google-jules-control/scripts/jules_api.py doctor --help >/tmp/google-jules-skill-doctor-help.txt
+python3 google-jules-control/scripts/jules_api.py check-pr-readiness --help >/tmp/google-jules-skill-pr-help.txt
+python3 google-jules-control/scripts/jules_api.py request-pr-rework --help >/tmp/google-jules-skill-rework-help.txt
+python3 google-jules-control/scripts/jules_api.py cleanup-report --help >/tmp/google-jules-skill-cleanup-help.txt
+python3 google-jules-control/scripts/jules_api.py close-ready-report --help >/tmp/google-jules-skill-close-ready-help.txt
 ```
+
+Packaging checks / 패키징 점검:
+
+```bash
+test -f README.md
+test -f google-jules-control/SKILL.md
+test -f google-jules-control/agents/openai.yaml
+test -f google-jules-control/.env.example
+grep -qx '.env' .gitignore
+grep -qx '.env' google-jules-control/.gitignore
+test -z "$(git ls-files | grep -E '(^|/)\.env$' || true)"
+```
+
+## Live Account Validation / 실제 계정 검증
+
+아래 명령은 실제 `JULES_API_KEY`, GitHub 인증, Jules에 연결된 target repository가 있을 때만 실행합니다.
+Run these only when a real `JULES_API_KEY`, GitHub auth, and a Jules-connected target repository are available.
+
+```bash
+: "${OWNER_REPO:?Set OWNER_REPO as owner/repo before live checks}"
+
+python3 google-jules-control/scripts/jules_api.py doctor --compact
+python3 google-jules-control/scripts/jules_api.py gh-auth-check --compact
+
+SOURCE="$(python3 google-jules-control/scripts/jules_api.py repo-to-source --repo "$OWNER_REPO" --compact)"
+test -n "$SOURCE" || { echo "No Jules source found for $OWNER_REPO"; exit 1; }
+printf '%s\n' "$SOURCE"
+
+python3 google-jules-control/scripts/jules_api.py list-sources >/tmp/google-jules-skill-sources.json
+python3 google-jules-control/scripts/jules_api.py cleanup-report --repo-filter "$OWNER_REPO" --compact
+python3 google-jules-control/scripts/jules_api.py close-ready-report --repo-filter "$OWNER_REPO" --markdown
+```
+
+통과 기준: `doctor --compact`에 `dotenv=yes api_key=yes api_ready=yes`가 포함되어야 합니다. merge-aware reporting이나 cleanup을 검증하려면 `merge_ready=yes`도 필요합니다.
+Pass criteria: `doctor --compact` must include `dotenv=yes api_key=yes api_ready=yes`. `merge_ready=yes` is also required before validating merge-aware reporting or cleanup.
+
+Smoke session handoff / 스모크 세션 handoff:
+
+- `docs/setup-and-test.md`의 `repo-to-source` -> `create-session` -> `summary` -> `export` -> cleanup 흐름을 한 번 실행 / Run the `repo-to-source` -> `create-session` -> `summary` -> `export` -> cleanup flow in `docs/setup-and-test.md` once
+- long-running 상태는 `wait` 또는 반복 `summary`로 확인 / Inspect long-running states with `wait` or repeated `summary`
+- 사람에게 보여줄 보고서는 `--markdown`, 자동화/보관용 결과는 JSON 또는 `export --output`으로 확인 / Use `--markdown` for human review and JSON or `export --output` for automation or archival checks
+
+## Platform Guide Release Checks / 플랫폼 가이드 릴리즈 점검
+
+- `Platform/README.md`의 공통 setup checks와 done criteria가 현재 명령 이름을 반영하는지 확인 / Confirm shared setup checks and done criteria in `Platform/README.md` reflect current command names
+- `Platform/Codex.md`, `Platform/Claude-Code.md`, `Platform/Google-Antigravity.md`가 skill registration 또는 project-doc injection, `.env` 접근, long-running command 처리, markdown/JSON 출력 처리를 각각 다루는지 확인 / Confirm each platform guide covers skill registration or project-doc injection, `.env` access, long-running command handling, and markdown/JSON output handling
+- full/strict 플랫폼 prompt 문서가 `doctor`, `repo-to-source`, `summary`, markdown report, concise JSON summary 흐름을 유지하는지 확인 / Confirm full and strict platform prompt docs preserve the `doctor`, `repo-to-source`, `summary`, markdown report, and concise JSON-summary flow
+
+## Version-Specific Notes / 버전별 확인 이력
+
+일반 릴리즈 절차와 분리해서 유지합니다. 새 버전에서만 필요한 수동 확인은 이 섹션에 추가하고, 다음 릴리즈에서 일반 절차로 승격할지 판단합니다.
+Keep these separate from the general release procedure. Add one-off manual checks for a specific release here, then decide in the next release whether they should become general procedure.
 
 `v0.2.0` focus / `v0.2.0` 중점 확인:
 
@@ -27,24 +88,6 @@ python3 /path/to/quick_validate.py google-jules-control
 - `close-ready-report --compact`가 `candidates`와 `caution` 요약을 정상 반환하는지 확인 / Confirm `close-ready-report --compact` returns the expected `candidates` and `caution` summary
 - `cleanup-report --compact`가 merged, unmerged, without-PR 분류를 정상 반환하는지 확인 / Confirm `cleanup-report --compact` returns merged, unmerged, and without-PR classification
 - API 제한 상황에서 quota 또는 rate-limit 오류 메시지가 명확하게 보이는지 확인 / Confirm quota or rate-limit failures surface a clear error message
-
-## 라이브 점검 / Live Checks
-
-```bash
-python3 google-jules-control/scripts/jules_api.py doctor --compact
-python3 google-jules-control/scripts/jules_api.py repo-to-source --repo owner/repo --compact
-python3 google-jules-control/scripts/jules_api.py list-sources
-python3 google-jules-control/scripts/jules_api.py close-ready-report --compact
-python3 google-jules-control/scripts/jules_api.py cleanup-report --compact
-```
-
-권장 / Recommended:
-
-- `--require-plan-approval`로 스모크 테스트 세션 1회 생성 / Create one smoke-test session with `--require-plan-approval`
-- 해당 세션에서 `summary` 확인 / Verify `summary` works for that session
-- 테스트 세션 또는 기존 세션으로 `check-pr-readiness`를 1회 확인 / Run `check-pr-readiness` once against a test or existing session
-- merge 불가 PR이 있다면 `request-pr-rework --markdown` 출력이 사용자에게 바로 전달 가능한지 확인 / If a PR is not merge-ready, confirm `request-pr-rework --markdown` produces a user-ready follow-up message
-- 테스트 후 세션 삭제 / Delete the smoke-test session afterward
 
 ## 배포 판단 / Deployment Judgment
 

--- a/docs/setup-and-test.md
+++ b/docs/setup-and-test.md
@@ -86,6 +86,9 @@ python3 google-jules-control/scripts/jules_api.py create-session \
 python3 google-jules-control/scripts/jules_api.py summary --session sessions/SESSION_ID
 ```
 
+`AWAITING_PLAN_APPROVAL` 상태라면 plan이 smoke-test 범위에 머무는지 먼저 확인합니다. 코드 변경, 리팩터링, 의존성 변경이 포함되면 승인하지 않습니다.
+If the session is `AWAITING_PLAN_APPROVAL`, review that the plan stays inside the smoke-test scope before approval. Do not approve plans that include code changes, refactors, or dependency changes.
+
 5. 테스트 세션 정리 / Clean up the test session
 
 이 단계는 되돌릴 수 없는 세션 삭제입니다. 테스트 세션을 삭제해도 된다고 확인한 뒤 실행합니다.
@@ -116,6 +119,9 @@ python3 google-jules-control/scripts/jules_api.py summary --session sessions/SES
 python3 google-jules-control/scripts/jules_api.py resume --session sessions/SESSION_ID --prompt "Continue."
 python3 google-jules-control/scripts/jules_api.py approve-plan --session sessions/SESSION_ID
 ```
+
+`approve-plan`과 `AWAITING_PLAN_APPROVAL` 세션을 승인할 수 있는 `resume`은 plan scope review 후에만 실행합니다.
+Run `approve-plan`, and `resume` when it would approve an `AWAITING_PLAN_APPROVAL` session, only after reviewing the generated plan against the task scope.
 
 정리와 리포트 / Cleanup and reporting:
 

--- a/docs/setup-and-test.md
+++ b/docs/setup-and-test.md
@@ -18,11 +18,49 @@ JULES_API_KEY=your_jules_api_key
 
 권장 위치 / Recommended locations:
 
-1. 저장소 루트 `.env` / Repository root `.env`
-2. 스킬 루트 `google-jules-control/.env` / Skill root `google-jules-control/.env`
+1. 스킬 루트 `google-jules-control/.env` / Skill root `google-jules-control/.env`
+2. 저장소 루트 `.env` / Repository root `.env`
 
 스크립트는 현재 작업 디렉토리를 먼저 보고, 없으면 스킬 루트를 봅니다.  
 The script checks the current working directory first, then the skill root.
+
+현재 작업 디렉토리에 `.env`가 이미 있으면 그 파일만 읽습니다. 그 파일에 `JULES_API_KEY`가 없으면 스킬 루트 `.env`로 자동 fallback하지 않습니다.
+If the current working directory already has `.env`, only that file is loaded. If it does not contain `JULES_API_KEY`, the helper does not fall back to the skill-root `.env`.
+
+## 설치와 호출 컨텍스트 / Install And Invocation Context
+
+`google-jules-control/` 폴더 자체가 스킬 패키지입니다. 에이전트가 스킬을 찾으려면 `SKILL.md`가 들어 있는 이 폴더를 skills 디렉터리에 등록합니다. Codex에 수동으로 로컬 스킬을 설치할 때는 보통 `${CODEX_HOME:-$HOME/.codex}/skills/google-jules-control`을 사용합니다.
+The `google-jules-control/` folder is the skill package. Register that folder, including its `SKILL.md`, in the agent skills directory. For manual local Codex skill installs, this usually means `${CODEX_HOME:-$HOME/.codex}/skills/google-jules-control`.
+
+`google-jules-control/agents/openai.yaml`은 이 manifest를 지원하는 OpenAI 계열 에이전트가 스킬 카드와 기본 프롬프트를 구성할 때 쓰는 파일입니다. `jules_api.py`의 runtime 설정은 `.env`와 CLI 인자로만 결정됩니다.
+`google-jules-control/agents/openai.yaml` is for OpenAI-style agents that support this manifest and need skill cards or default prompts. `jules_api.py` runtime behavior comes from `.env` and CLI arguments, not from that YAML file.
+
+등록 확인 / Discoverability check:
+
+```text
+Use $google-jules-control to run doctor --compact and summarize the result.
+```
+
+에이전트가 `$google-jules-control`을 모른다면 설치 위치, 폴더 이름, `SKILL.md` front matter의 `name: google-jules-control`을 확인합니다.
+If the agent does not recognize `$google-jules-control`, check the install path, folder name, and `name: google-jules-control` front matter in `SKILL.md`.
+
+스킬 저장소 루트에서 실행 / Run from this skill repository root:
+
+```bash
+python3 google-jules-control/scripts/jules_api.py doctor --compact
+python3 google-jules-control/scripts/jules_api.py repo-to-source --repo owner/repo --compact
+```
+
+스킬 루트에서 실행 / Run from the skill root:
+
+```bash
+cd google-jules-control
+python3 scripts/jules_api.py doctor --compact
+python3 scripts/jules_api.py repo-to-source --repo owner/repo --compact
+```
+
+`export --output` 경로는 현재 shell 작업 디렉토리 기준입니다. 대상 저장소와 스킬 저장소가 헷갈리면 절대 경로를 쓰거나 `pwd`로 위치를 먼저 확인합니다.
+`export --output` paths are relative to the current shell working directory. If the target repo and skill repo are easy to confuse, use an absolute path or check `pwd` first.
 
 ## 상태 점검 / Readiness Check
 
@@ -57,37 +95,64 @@ Plain `doctor --compact` does not make a network API call. In that mode, `api_ke
 
 ## 기본 스모크 테스트 / Basic Smoke Test
 
-1. 소스 목록 확인 / Verify source listing
+아래 예시는 스킬 저장소 루트에서 실행하는 copy-paste 흐름입니다. `owner/repo`와 `main`만 실제 값으로 바꿉니다.
+The example below is a copy-paste flow from this skill repository root. Replace only `owner/repo` and `main`.
+
+1. 소스 확인과 handoff 값 저장 / Resolve the source and keep the handoff value
 
 ```bash
-python3 google-jules-control/scripts/jules_api.py list-sources
+OWNER_REPO=owner/repo
+BRANCH=main
+SOURCE="$(python3 google-jules-control/scripts/jules_api.py repo-to-source --repo "$OWNER_REPO" --compact)"
+test -n "$SOURCE" || { echo "No Jules source found. Connect $OWNER_REPO in Jules, then retry."; exit 1; }
+printf '%s\n' "$SOURCE"
 ```
 
-2. 저장소를 source로 해석 / Resolve a repository
+예상 출력 / Expected output:
 
-```bash
-python3 google-jules-control/scripts/jules_api.py repo-to-source --repo owner/repo --compact
+```text
+sources/github/owner/repo
 ```
 
-3. 가벼운 테스트 세션 생성 / Create a lightweight test session
+2. 가벼운 테스트 세션 생성과 session id 저장 / Create a lightweight session and keep the session id
 
 ```bash
-python3 google-jules-control/scripts/jules_api.py create-session \
-  --source sources/github/owner/repo \
-  --branch main \
+SESSION_JSON="$(python3 google-jules-control/scripts/jules_api.py create-session \
+  --source "$SOURCE" \
+  --branch "$BRANCH" \
   --title "Smoke test" \
   --prompt "Smoke test only: inspect the repository at a high level and summarize the top-level structure without making code changes." \
-  --require-plan-approval
+  --require-plan-approval)"
+SESSION="$(printf '%s\n' "$SESSION_JSON" | python3 -c 'import json, sys; print(json.load(sys.stdin)["name"])')"
+printf '%s\n' "$SESSION"
 ```
 
-4. 세션 확인 / Check the session
+예상 출력 / Expected output:
+
+```text
+sessions/1234567890
+```
+
+3. 세션 확인 / Check the session
 
 ```bash
-python3 google-jules-control/scripts/jules_api.py summary --session sessions/SESSION_ID
+python3 google-jules-control/scripts/jules_api.py summary --session "$SESSION"
 ```
 
 `AWAITING_PLAN_APPROVAL` 상태라면 plan이 smoke-test 범위에 머무는지 먼저 확인합니다. 코드 변경, 리팩터링, 의존성 변경이 포함되면 승인하지 않습니다.
 If the session is `AWAITING_PLAN_APPROVAL`, review that the plan stays inside the smoke-test scope before approval. Do not approve plans that include code changes, refactors, or dependency changes.
+
+4. 필요하면 summary를 파일로 export / Optionally export the summary to a file
+
+```bash
+python3 google-jules-control/scripts/jules_api.py export \
+  --session "$SESSION" \
+  --kind summary \
+  --output jules-session-summary.json
+```
+
+스킬 저장소 루트에서 실행했다면 `jules-session-summary.json`도 스킬 저장소 루트에 생기며, 대상 `owner/repo` 저장소에는 쓰이지 않습니다.
+When this is run from the skill repository root, `jules-session-summary.json` is written there, not into the target `owner/repo` repository.
 
 5. 테스트 세션 정리 / Clean up the test session
 
@@ -96,7 +161,7 @@ This is irreversible session deletion. Run it only after confirming the test ses
 
 ```bash
 python3 google-jules-control/scripts/jules_api.py delete-session \
-  --session sessions/SESSION_ID \
+  --session "$SESSION" \
   --confirm-delete DELETE_JULES_SESSION
 ```
 

--- a/docs/setup-and-test.md
+++ b/docs/setup-and-test.md
@@ -28,19 +28,23 @@ The script checks the current working directory first, then the skill root.
 
 ```bash
 python3 google-jules-control/scripts/jules_api.py doctor --compact
+python3 google-jules-control/scripts/jules_api.py doctor --compact --validate-api
 ```
 
-정상 예시 / Healthy example:
+검증 포함 정상 예시 / Healthy example with API validation:
 
 ```text
-dotenv=yes api_key=yes api_ready=yes gh=yes gh_auth=yes merge_ready=yes jules_cli=no jules_cli_auth=not_installed cli_ready=no ready=yes
+dotenv=yes api_key=yes api_validated=yes api_status=ok api_ready=yes gh=yes gh_auth=yes merge_ready=yes jules_cli=no jules_cli_auth=not_installed cli_ready=no ready=yes
 ```
 
 REST API만 쓴다면 `jules_cli=no`는 문제 아닙니다.  
 `jules_cli=no` is acceptable if you only use the REST API path.
 
-`api_ready=yes`는 API helper가 바로 실행 가능한 상태를 뜻합니다.  
-`api_ready=yes` means the REST API helper can run.
+기본 `doctor --compact`는 네트워크 API 호출을 하지 않습니다. 이 경우 `api_key=yes`는 키가 있다는 뜻이고, `api_ready=yes`는 아닙니다.
+Plain `doctor --compact` does not make a network API call. In that mode, `api_key=yes` means the key is present, not that `api_ready=yes`.
+
+`api_ready=yes`는 `--validate-api` probe가 성공해서 현재 키로 Jules API 인증이 확인됐다는 뜻입니다.
+`api_ready=yes` means the `--validate-api` probe succeeded and the current key authenticated with the Jules API.
 
 `cli_ready=yes`는 Jules CLI 경로도 바로 쓸 수 있다는 뜻입니다.  
 `cli_ready=yes` means the Jules CLI path is also ready to use.
@@ -127,8 +131,8 @@ python3 google-jules-control/scripts/jules_api.py stale-session-report --repo-fi
 
 - `ready=no`: `doctor`를 `--compact` 없이 실행해서 어떤 항목이 비었는지 확인합니다.  
   Run `doctor` without `--compact` to see the missing dependency.
-- `api_ready=no`: `.env`와 `JULES_API_KEY`를 먼저 점검합니다.  
-  Check `.env` and `JULES_API_KEY` first.
+- `api_ready=no`: `api_key`, `api_validated`, `api_status`를 함께 봅니다. 검증이 필요하면 `doctor --compact --validate-api`를 실행합니다.
+  Check `api_key`, `api_validated`, and `api_status` together. Run `doctor --compact --validate-api` when you need credential validation.
 - `cli_ready=no`: CLI 경로를 쓰려면 `jules login` 또는 CLI 인증 상태를 확인합니다.  
   If you want the CLI path, check `jules login` or the CLI authentication state.
 - `merge_ready=no`: merge 기반 리포트 전에 `gh auth status`를 확인합니다.  

--- a/docs/setup-and-test.md
+++ b/docs/setup-and-test.md
@@ -88,8 +88,13 @@ python3 google-jules-control/scripts/jules_api.py summary --session sessions/SES
 
 5. 테스트 세션 정리 / Clean up the test session
 
+이 단계는 되돌릴 수 없는 세션 삭제입니다. 테스트 세션을 삭제해도 된다고 확인한 뒤 실행합니다.
+This is irreversible session deletion. Run it only after confirming the test session can be deleted.
+
 ```bash
-python3 google-jules-control/scripts/jules_api.py delete-session --session sessions/SESSION_ID
+python3 google-jules-control/scripts/jules_api.py delete-session \
+  --session sessions/SESSION_ID \
+  --confirm-delete DELETE_JULES_SESSION
 ```
 
 ## 자주 쓰는 명령 / Common Commands

--- a/google-jules-control/SKILL.md
+++ b/google-jules-control/SKILL.md
@@ -20,7 +20,7 @@ Use this skill to delegate coding work to Google Jules from an agentic workflow.
    - CLI path: run `jules remote list --repo` or use `jules remote new --repo .` from the repo root.
 3. Create a session with a concrete prompt and branch. By default the script wraps the prompt with a strict-scope contract so Jules stays narrow and asks questions when needed.
 4. Poll session state or activities until Jules requests approval, feedback, or completes.
-5. Approve the latest plan if the session enters `AWAITING_PLAN_APPROVAL`.
+5. If the session enters `AWAITING_PLAN_APPROVAL`, review the latest plan against the original task, strict-scope rules, `--scope-note`, and `--non-goal` before approving it.
 6. If needed, inspect open sessions with `list-active-sessions`.
 7. For completed PR work, verify merge status before closing the Jules session.
 8. Summarize results for the user, including session URL, current state, latest agent message, PR status, and whether the session is safe to close.
@@ -72,6 +72,10 @@ python3 scripts/jules_api.py create-session \
 
 python3 scripts/jules_api.py wait --session sessions/1234567890
 
+python3 scripts/jules_api.py summary --session sessions/1234567890
+
+# Before approving, run a scope review against the original task,
+# --scope-note, --non-goal, and strict-scope rules.
 python3 scripts/jules_api.py approve-plan --session sessions/1234567890
 
 python3 scripts/jules_api.py send-message \
@@ -176,13 +180,30 @@ Approve the current Jules plan and let it continue.
 
 Suggested flow:
 
+Before approving, compare the generated plan with:
+
+- The original user request
+- Any `--scope-note` boundaries
+- Any `--non-goal` exclusions
+- The strict-scope rules that forbid unrelated cleanup, dependency changes, schema changes, broad refactors, or adjacent formatting changes
+
+If the plan drifts outside scope, do not approve it. Ask the user for confirmation or send Jules a follow-up asking for a narrower plan, for example:
+
 ```bash
 python3 scripts/jules_api.py summary --session sessions/SESSION_ID
 python3 scripts/jules_api.py approve-plan --session sessions/SESSION_ID
 python3 scripts/jules_api.py wait --session sessions/SESSION_ID
 ```
 
-Use `resume` instead when you want one helper command that can approve a pending plan automatically:
+```bash
+python3 scripts/jules_api.py send-message \
+  --session sessions/SESSION_ID \
+  --prompt "Revise the plan before execution. Keep it limited to the login redirect test and remove the proposed auth helper refactor." \
+  --scope-note "Only the login redirect path and its direct tests are in scope." \
+  --non-goal "Do not refactor shared auth helpers."
+```
+
+Use `resume` only after the same scope review when you want one helper command that can approve a pending plan automatically:
 
 ```bash
 python3 scripts/jules_api.py resume --session sessions/SESSION_ID
@@ -461,7 +482,8 @@ python3 scripts/jules_api.py close-ready-report --repo-filter owner/repo --requi
 - Prompts sent through the API helper are strict-scope by default. Use that default unless there is a clear reason to opt out.
 - Treat strict-scope as both a simplicity rule and a surgical-change rule: minimum necessary patch, minimum necessary blast radius.
 - If the user gives only an owner/repo pair and not a Jules source resource name, resolve it with `list-sources` first.
-- If `AWAITING_PLAN_APPROVAL` appears, surface the plan and explicitly approve it only when the user asked to continue or the task clearly implies execution should proceed.
+- If `AWAITING_PLAN_APPROVAL` appears, surface the plan and run a scope review before approval. Approve only when the plan stays within the original request, `--scope-note`, `--non-goal`, and strict-scope rules.
+- If the plan includes scope drift, unrelated cleanup, dependency changes, schema changes, broad refactors, or adjacent formatting changes, do not approve it by default. Ask the user or send Jules a narrowing instruction first.
 - If the session reaches `AWAITING_USER_FEEDBACK`, send a concise clarifying instruction instead of creating a new session.
 - Use `resume` as a convenience helper only. It is not a first-class Jules API verb; it infers the right next step from the session state.
 - Use `--scope-note` when a file area, subsystem, or execution boundary must be stated explicitly.

--- a/google-jules-control/SKILL.md
+++ b/google-jules-control/SKILL.md
@@ -9,6 +9,8 @@ Use this skill to delegate coding work to Google Jules from an agentic workflow.
 
 ## Quick Start
 
+The command examples in this file assume your shell is in the skill root (`google-jules-control/`). From this skill repository root, prefix script paths with `google-jules-control/`, for example `python3 google-jules-control/scripts/jules_api.py doctor --compact`.
+
 1. Verify one control path is available.
    - API path: put `JULES_API_KEY` in a `.env` file from `https://jules.google.com/settings`.
    - CLI path: install `@google/jules`, then run `jules login`.
@@ -560,7 +562,7 @@ You can start from `.env.example`.
 
 `.gitignore` excludes `.env`, so the real key file is less likely to be committed by accident.
 
-The script auto-loads `.env` from the current working directory first, then from the skill root.
+The script auto-loads `.env` from the current working directory first, then from the skill root. If the current working directory has `.env`, that file must contain `JULES_API_KEY`; the helper does not merge it with the skill-root `.env`.
 
 ## Read More Only When Needed
 

--- a/google-jules-control/SKILL.md
+++ b/google-jules-control/SKILL.md
@@ -249,10 +249,15 @@ Suggested flow:
 
 ```bash
 python3 scripts/jules_api.py summary --session sessions/SESSION_ID
-python3 scripts/jules_api.py cancel-session --session sessions/SESSION_ID
 ```
 
-State clearly that this is implemented as session deletion and is not a reversible pause.
+State clearly that cancel is implemented as session deletion and is not a reversible pause. After explicit user confirmation, run:
+
+```bash
+python3 scripts/jules_api.py cancel-session \
+  --session sessions/SESSION_ID \
+  --confirm-delete DELETE_JULES_SESSION
+```
 
 ### Example: Check active sessions and close a merged one safely
 
@@ -463,7 +468,7 @@ python3 scripts/jules_api.py close-ready-report --repo-filter owner/repo --requi
 - Use `--non-goal` when you need to forbid refactors, cleanup, dependency changes, schema changes, or other adjacent work.
 - If the task is ambiguous, prefer a follow-up question over a broader instruction.
 - Prefer goal-driven follow-ups with explicit verification targets over vague “improve this” style prompts.
-- Treat `cancel-session` as destructive. It maps to session deletion, not a reversible pause.
+- Treat `delete-session` and `cancel-session` as destructive. They map to irreversible session deletion, not a reversible pause, and require explicit user confirmation plus `--confirm-delete DELETE_JULES_SESSION`.
 - For merged-work cleanup, always follow this order: inspect session, verify merged PR status, ask the user, then run `close-merged-session`.
 - Use `--require-all-merged` when the session output contains more than one pull request URL.
 - Use `list-unmerged-sessions` when the user wants a single view of work that is still open on GitHub.
@@ -515,6 +520,11 @@ The bundled script lives at `scripts/jules_api.py` and supports:
 - `close-merged-session`
 
 Run `python3 scripts/jules_api.py --help` or `python3 scripts/jules_api.py <command> --help` for flags.
+
+Destructive commands intentionally require safety tokens:
+
+- `delete-session` and `cancel-session`: `--confirm-delete DELETE_JULES_SESSION`
+- `close-merged-session`: `--confirm-close CLOSE_MERGED_SESSION`
 
 ## Credential Setup
 

--- a/google-jules-control/SKILL.md
+++ b/google-jules-control/SKILL.md
@@ -20,7 +20,7 @@ The command examples in this file assume your shell is in the skill root (`googl
 2. Discover the target repository/source.
    - API path: run `python3 scripts/jules_api.py repo-to-source --repo owner/repo --compact` or `python3 scripts/jules_api.py list-sources`.
    - CLI path: run `jules remote list --repo` or use `jules remote new --repo .` from the repo root.
-3. Create a session with a concrete prompt and branch. By default the script wraps the prompt with a strict-scope contract so Jules stays narrow and asks questions when needed.
+3. Create a session with a concrete prompt and starting branch. By default the script wraps the prompt with a strict-scope contract so Jules stays narrow and asks questions when needed.
 4. Poll session state or activities until Jules requests approval, feedback, or completes.
 5. If the session enters `AWAITING_PLAN_APPROVAL`, review the latest plan against the original task, strict-scope rules, `--scope-note`, and `--non-goal` before approving it.
 6. If needed, inspect open sessions with `list-active-sessions`.
@@ -125,6 +125,18 @@ Notes:
 - `doctor --compact` separates `api_key`, `api_validated`, `api_ready`, `cli_ready`, and `merge_ready`.
 - `api_key=yes` only means the key is present. Use `doctor --compact --validate-api` when you need to prove that the key can authenticate.
 - Aggregated list/report commands collect all pages by default. `--page-token` is a starting point for aggregation, not a single-page mode.
+
+### Branch and PR creation choices
+
+`create-session --branch` maps to Jules API `sourceContext.githubRepoContext.startingBranch`. It is the remote branch Jules starts from in the connected GitHub repository, not a local checkout path.
+
+Choose the branch before creating the session:
+
+- Default branch: use the repository default branch when starting ordinary new work. If the user does not name a branch, check it first, for example `gh repo view owner/repo --json defaultBranchRef -q .defaultBranchRef.name`. Some repositories use `trunk`, `develop`, or `master` instead of `main`.
+- Release branch: use a branch such as `release/1.4` only when the requested fix must target that release line. State the release boundary in `--scope-note`.
+- Existing feature branch: use an existing remote branch such as `feature/login-redirect` only when the user wants Jules to continue that branch. Confirm the branch is pushed, tell Jules to preserve the existing branch intent, and avoid unrelated cleanup that could collide with in-flight work.
+
+`--automation-mode AUTO_CREATE_PR` asks Jules to create a pull request automatically when the session produces changes. Enable it only when the user wants Jules to open a PR as part of the run and the target branch is clear. Omit it for investigation, smoke tests, plan-only sessions, existing PR rework, or cases where you want to inspect/pull the work before deciding whether to open a PR.
 
 ### CLI workflow
 
@@ -481,6 +493,8 @@ python3 scripts/jules_api.py close-ready-report --repo-filter owner/repo --requi
 - Prefer the CLI for human-driven terminal workflows, quick repo inference from the current directory, or pulling a completed patch into the local checkout.
 - Use `summary` or `list-activities` before responding so the user gets the latest agent-visible state, not just the initial session creation response.
 - Treat Jules as asynchronous. After `create-session`, `send-message`, or `approve-plan`, poll for updated activities instead of assuming immediate textual output.
+- Treat `create-session --branch` as the remote starting branch for Jules' work. Check the default branch when the user does not specify one.
+- Use `--automation-mode AUTO_CREATE_PR` only when automatic PR creation is an intended side effect.
 - Prompts sent through the API helper are strict-scope by default. Use that default unless there is a clear reason to opt out.
 - Treat strict-scope as both a simplicity rule and a surgical-change rule: minimum necessary patch, minimum necessary blast radius.
 - If the user gives only an owner/repo pair and not a Jules source resource name, resolve it with `list-sources` first.

--- a/google-jules-control/SKILL.md
+++ b/google-jules-control/SKILL.md
@@ -13,6 +13,7 @@ Use this skill to delegate coding work to Google Jules from an agentic workflow.
    - API path: put `JULES_API_KEY` in a `.env` file from `https://jules.google.com/settings`.
    - CLI path: install `@google/jules`, then run `jules login`.
    - API/CLI health check: run `python3 scripts/jules_api.py doctor --compact`.
+   - API credential validation: run `python3 scripts/jules_api.py doctor --compact --validate-api`.
    - Merge-aware reporting health check: run `python3 scripts/jules_api.py gh-auth-check --compact`.
 2. Discover the target repository/source.
    - API path: run `python3 scripts/jules_api.py repo-to-source --repo owner/repo --compact` or `python3 scripts/jules_api.py list-sources`.
@@ -115,7 +116,8 @@ python3 scripts/jules_api.py summary --session sessions/1234567890
 
 Notes:
 
-- `doctor --compact` now separates `api_ready`, `cli_ready`, and `merge_ready`.
+- `doctor --compact` separates `api_key`, `api_validated`, `api_ready`, `cli_ready`, and `merge_ready`.
+- `api_key=yes` only means the key is present. Use `doctor --compact --validate-api` when you need to prove that the key can authenticate.
 - Aggregated list/report commands collect all pages by default. `--page-token` is a starting point for aggregation, not a single-page mode.
 
 ### CLI workflow
@@ -474,7 +476,7 @@ python3 scripts/jules_api.py close-ready-report --repo-filter owner/repo --requi
 - Use `close-ready-report` when the user wants close candidates plus ready-made close confirmation text in one step.
 - Prefer `--markdown` for human review and `--compact` for scripting or automation chaining.
 - Prefer a local `.env` file over shell profile edits for `JULES_API_KEY`. The script auto-loads `.env` from the current working directory or the skill root.
-- Use `doctor` before the first live run to verify `.env`, `JULES_API_KEY`, `gh`, and `jules` CLI readiness in one place.
+- Use `doctor` before the first live run to inspect `.env`, `JULES_API_KEY`, `gh`, and `jules` CLI readiness in one place. Add `--validate-api` when API credential validity matters.
 - Use `repo-to-source` when the user gives only `owner/repo` and you need the exact Jules source resource name.
 - Use `check-pr-readiness` before cleanup when you need to know whether a PR is actually merge-ready, not just merged or open.
 - Use `request-pr-rework` when GitHub reports blockers such as merge conflicts, failed checks, or requested changes and you want a follow-up message for Jules.

--- a/google-jules-control/references/jules-reference.md
+++ b/google-jules-control/references/jules-reference.md
@@ -48,7 +48,7 @@ Important session fields:
 Practical note:
 
 - There is no dedicated REST `resume` endpoint in the current public API. If a session is waiting, resume it by approving a pending plan or sending a follow-up message.
-- There is no reversible REST `cancel` endpoint distinct from deletion. Deleting the session is the closest cancellation-style action.
+- There is no reversible REST `cancel` endpoint distinct from deletion. Deleting the session is the closest cancellation-style action, so `delete-session` and `cancel-session` require `--confirm-delete DELETE_JULES_SESSION` after explicit user confirmation.
 - The public API does not document a reliable remaining-usage or quota-balance endpoint for end users. Handle quota failures explicitly, but do not guess a remaining amount.
 
 Activity types to watch:
@@ -108,6 +108,8 @@ The bundled `jules_api.py` script automates this with:
 - `check-pr-readiness --session ...`
 - `request-pr-rework --session ... --markdown`
 - `notify-close-plan --session ... --markdown`
+- `delete-session --session ... --confirm-delete DELETE_JULES_SESSION`
+- `cancel-session --session ... --confirm-delete DELETE_JULES_SESSION`
 - `close-merged-session --session ... --confirm-close CLOSE_MERGED_SESSION`
 
 Implementation detail:
@@ -119,6 +121,7 @@ Implementation detail:
 - `doctor` separates `api_key`, `api_validated`, `api_ready`, `cli_ready`, and `merge_ready`. Without `--validate-api`, `api_key=yes` only means the key is present. With `--validate-api`, `api_ready=yes` means the API probe authenticated successfully. `ready=yes` means at least one validated control path is available.
 - `close-ready-report` distinguishes between `candidates` and `cautionCandidates`. Treat caution entries as manual-review items, not automatic close targets.
 - `close-merged-session` refuses `caution` sessions by default. Only use `--allow-caution-close` after explicit user approval.
+- `delete-session` and `cancel-session` refuse to run without the explicit delete token because both are irreversible deletion flows.
 
 Pagination contract:
 

--- a/google-jules-control/references/jules-reference.md
+++ b/google-jules-control/references/jules-reference.md
@@ -39,9 +39,9 @@ Core resources:
 Important session fields:
 
 - `sourceContext.source`: full source resource name such as `sources/github/OWNER/REPO`
-- `sourceContext.githubRepoContext.startingBranch`: required branch name
+- `sourceContext.githubRepoContext.startingBranch`: required branch name. This is the remote branch Jules starts from; it is not a local checkout path.
 - `requirePlanApproval`: if true, execution pauses for approval
-- `automationMode`: `AUTO_CREATE_PR` or omitted
+- `automationMode`: `AUTO_CREATE_PR` or omitted. `AUTO_CREATE_PR` asks Jules to create a pull request automatically when changes are ready.
 - `state`: one of `QUEUED`, `PLANNING`, `AWAITING_PLAN_APPROVAL`, `AWAITING_USER_FEEDBACK`, `IN_PROGRESS`, `PAUSED`, `FAILED`, `COMPLETED`
 - `url`: Jules web URL for the session
 
@@ -51,6 +51,9 @@ Practical note:
 - There is no reversible REST `cancel` endpoint distinct from deletion. Deleting the session is the closest cancellation-style action, so `delete-session` and `cancel-session` require `--confirm-delete DELETE_JULES_SESSION` after explicit user confirmation.
 - The public API does not document a reliable remaining-usage or quota-balance endpoint for end users. Handle quota failures explicitly, but do not guess a remaining amount.
 - `AWAITING_PLAN_APPROVAL` is a review gate, not an automatic approval signal. Read the generated plan and compare it with the original task, scope notes, non-goals, and strict-scope rules before calling `approve-plan`.
+- If the user does not specify a branch, check the repository default branch before using `--branch`; not every repository uses `main`.
+- Use an existing feature branch only when the user wants Jules to continue that remote branch, and include scope notes that preserve the branch intent.
+- Omit `AUTO_CREATE_PR` for investigation, smoke tests, plan-only sessions, existing PR rework, or workflows where a human should inspect the output before opening a PR.
 
 Activity types to watch:
 

--- a/google-jules-control/references/jules-reference.md
+++ b/google-jules-control/references/jules-reference.md
@@ -95,6 +95,7 @@ The Jules REST API does not expose GitHub merge state directly. To close a sessi
 The bundled `jules_api.py` script automates this with:
 
 - `doctor --compact`
+- `doctor --compact --validate-api`
 - `gh-auth-check --compact`
 - `repo-to-source --repo owner/repo --compact`
 - `cleanup-report --repo-filter owner/repo --require-all-merged`
@@ -115,7 +116,7 @@ Implementation detail:
 - Merge readiness is checked through `gh pr view <url> --json mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,...`.
 - If `gh` is missing or unauthenticated, merge status falls back to `unknown` and close should not proceed automatically.
 - `gh-auth-check` is the fast preflight check before any merge-aware report.
-- `doctor` separates `api_ready`, `cli_ready`, and `merge_ready`. `ready=yes` means at least one control path is available.
+- `doctor` separates `api_key`, `api_validated`, `api_ready`, `cli_ready`, and `merge_ready`. Without `--validate-api`, `api_key=yes` only means the key is present. With `--validate-api`, `api_ready=yes` means the API probe authenticated successfully. `ready=yes` means at least one validated control path is available.
 - `close-ready-report` distinguishes between `candidates` and `cautionCandidates`. Treat caution entries as manual-review items, not automatic close targets.
 - `close-merged-session` refuses `caution` sessions by default. Only use `--allow-caution-close` after explicit user approval.
 

--- a/google-jules-control/references/jules-reference.md
+++ b/google-jules-control/references/jules-reference.md
@@ -47,9 +47,10 @@ Important session fields:
 
 Practical note:
 
-- There is no dedicated REST `resume` endpoint in the current public API. If a session is waiting, resume it by approving a pending plan or sending a follow-up message.
+- There is no dedicated REST `resume` endpoint in the current public API. If a session is waiting, resume it by approving a pending plan only after comparing it against the original task, scope notes, non-goals, and strict-scope rules, or by sending a follow-up message.
 - There is no reversible REST `cancel` endpoint distinct from deletion. Deleting the session is the closest cancellation-style action, so `delete-session` and `cancel-session` require `--confirm-delete DELETE_JULES_SESSION` after explicit user confirmation.
 - The public API does not document a reliable remaining-usage or quota-balance endpoint for end users. Handle quota failures explicitly, but do not guess a remaining amount.
+- `AWAITING_PLAN_APPROVAL` is a review gate, not an automatic approval signal. Read the generated plan and compare it with the original task, scope notes, non-goals, and strict-scope rules before calling `approve-plan`.
 
 Activity types to watch:
 
@@ -137,5 +138,6 @@ Pagination contract:
 - `Usage or rate limit exceeded`: retry later, reduce automation frequency, or check the Jules account/project limits. The script will fail clearly instead of estimating remaining usage.
 - No matching source: install/connect the GitHub repository in Jules first, then re-run `list-sources`.
 - Session appears stuck: inspect the latest activities and state before retrying. `AWAITING_PLAN_APPROVAL` and `AWAITING_USER_FEEDBACK` are usually waiting states, not failures.
+- Plan includes unrelated work: do not approve it by default. Send Jules a narrowing instruction or ask the user whether the broader scope is intentional.
 - Need richer repo context: keep the repository `AGENTS.md` current so Jules can infer project-specific conventions.
 - `gh pr view` fails: run `gh auth status` and authenticate the right GitHub account before using merge-status commands.

--- a/google-jules-control/scripts/jules_api.py
+++ b/google-jules-control/scripts/jules_api.py
@@ -18,7 +18,8 @@ import urllib.parse
 import urllib.request
 from typing import Any
 
-DEFAULT_BASE_URL = os.environ.get("JULES_API_BASE_URL", "https://jules.googleapis.com/v1alpha")
+DEFAULT_BASE_URL = "https://jules.googleapis.com/v1alpha"
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 60
 DEFAULT_TIMEOUT_SECONDS = 60 * 20
 ACTIVE_STATES = {"QUEUED", "PLANNING", "IN_PROGRESS", "PAUSED"}
 WAITING_STATES = {"AWAITING_PLAN_APPROVAL", "AWAITING_USER_FEEDBACK"}
@@ -186,7 +187,8 @@ def build_prompt_from_args(
 
 def build_url(path: str, query: dict[str, Any] | None = None) -> str:
     path = path if path.startswith("/") else f"/{path}"
-    url = f"{DEFAULT_BASE_URL}{path}"
+    base_url = os.environ.get("JULES_API_BASE_URL", DEFAULT_BASE_URL).strip() or DEFAULT_BASE_URL
+    url = f"{base_url.rstrip('/')}{path}"
     if query:
         filtered = {key: value for key, value in query.items() if value not in (None, "", False)}
         if filtered:
@@ -205,7 +207,7 @@ def api_request(method: str, path: str, *, payload: dict[str, Any] | None = None
         data = json.dumps(payload).encode("utf-8")
     request = urllib.request.Request(build_url(path, query), data=data, headers=headers, method=method.upper())
     try:
-        with urllib.request.urlopen(request) as response:
+        with urllib.request.urlopen(request, timeout=DEFAULT_REQUEST_TIMEOUT_SECONDS) as response:
             raw = response.read().decode("utf-8").strip()
     except urllib.error.HTTPError as exc:
         body = exc.read().decode("utf-8", errors="replace").strip()
@@ -215,7 +217,10 @@ def api_request(method: str, path: str, *, payload: dict[str, Any] | None = None
 
     if not raw:
         return {}
-    return json.loads(raw)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        fail("Jules API request returned non-JSON data. Check the API endpoint, credentials, and network/proxy settings.")
 
 
 def build_api_error_message(status_code: int, raw_body: str) -> str:
@@ -543,17 +548,30 @@ def collect_status_check_blockers(checks: Any) -> list[str]:
         name = check.get("name") or check.get("context") or "status-check"
         status = normalize_gh_state(check.get("status"))
         conclusion = normalize_gh_state(check.get("conclusion"))
+        state = normalize_gh_state(check.get("state"))
+        signals = [signal for signal in [conclusion, state, status] if signal]
 
-        if conclusion in FAILED_CHECK_CONCLUSIONS:
-            blockers.append(f"{name}={conclusion}")
+        failed_signal = next((signal for signal in signals if signal in FAILED_CHECK_CONCLUSIONS), None)
+        if failed_signal:
+            blockers.append(f"{name}={failed_signal}")
             continue
 
-        if status in PENDING_CHECK_STATUSES:
-            blockers.append(f"{name}={status}")
+        pending_signal = next((signal for signal in signals if signal in PENDING_CHECK_STATUSES), None)
+        if pending_signal:
+            blockers.append(f"{name}={pending_signal}")
             continue
 
         if status == "COMPLETED" and conclusion not in SUCCESSFUL_CHECK_CONCLUSIONS:
             blockers.append(f"{name}={conclusion or 'UNKNOWN'}")
+            continue
+
+        if any(signal in SUCCESSFUL_CHECK_CONCLUSIONS for signal in signals):
+            continue
+
+        if signals:
+            blockers.append(f"{name}={signals[0]}")
+        else:
+            blockers.append(f"{name}=UNKNOWN")
     return blockers
 
 
@@ -1543,6 +1561,8 @@ def request_pr_rework(args: argparse.Namespace) -> None:
     readiness = [summarize_pr_merge_readiness(pr) for pr in report.get("pullRequests", [])]
     blocked = [item for item in readiness if not item["ready"]]
 
+    if not readiness:
+        fail("No pull request URL was found for this session. Wait for Jules to produce a PR, or inspect the session outputs first.")
     if not blocked:
         fail("All discovered PRs look merge-ready. No rework request message is needed.")
 

--- a/google-jules-control/scripts/jules_api.py
+++ b/google-jules-control/scripts/jules_api.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import datetime as dt
+import io
 import json
 import os
 from pathlib import Path
@@ -425,6 +427,43 @@ def collect_jules_cli_status() -> dict[str, Any]:
             payload["authStatus"] = "unknown"
         payload["authProbeError"] = combined or "Failed to determine Jules CLI authentication state."
         return payload
+
+
+def collect_api_validation_status(*, validate: bool) -> dict[str, Any]:
+    api_key_present = bool(os.environ.get("JULES_API_KEY", "").strip())
+    if not validate:
+        return {
+            "validated": False,
+            "ready": False,
+            "status": "not_checked",
+            "reason": "Run doctor --validate-api to verify Jules API credentials.",
+        }
+    if not api_key_present:
+        return {
+            "validated": True,
+            "ready": False,
+            "status": "missing_key",
+            "reason": "JULES_API_KEY is not set.",
+        }
+
+    stderr = io.StringIO()
+    try:
+        with contextlib.redirect_stderr(stderr):
+            api_request("GET", "/sources", query={"pageSize": 1})
+    except SystemExit as exc:
+        reason = stderr.getvalue().strip() or f"API validation failed with exit code {exc.code}."
+        return {
+            "validated": True,
+            "ready": False,
+            "status": "failed",
+            "reason": reason,
+        }
+
+    return {
+        "validated": True,
+        "ready": True,
+        "status": "ok",
+    }
 
 
 def format_session_line(session: dict[str, Any]) -> str:
@@ -1647,7 +1686,8 @@ def doctor(args: argparse.Namespace) -> None:
     api_key_present = bool(os.environ.get("JULES_API_KEY", "").strip())
     gh_status = collect_gh_auth_status()
     jules_status = collect_jules_cli_status()
-    api_ready = api_key_present
+    api_validation = collect_api_validation_status(validate=args.validate_api)
+    api_ready = bool(api_validation["ready"])
     cli_ready = bool(jules_status.get("ready"))
     merge_ready = bool(gh_status.get("installed") and gh_status.get("authenticated"))
 
@@ -1659,6 +1699,7 @@ def doctor(args: argparse.Namespace) -> None:
         "julesApiKey": {
             "present": api_key_present,
         },
+        "julesApiValidation": api_validation,
         "gh": gh_status,
         "julesCli": jules_status,
         "apiReady": api_ready,
@@ -1674,6 +1715,8 @@ def doctor(args: argparse.Namespace) -> None:
                 [
                     f"dotenv={'yes' if payload['dotenv']['found'] else 'no'}",
                     f"api_key={'yes' if api_key_present else 'no'}",
+                    f"api_validated={'yes' if api_validation['validated'] else 'no'}",
+                    f"api_status={api_validation['status']}",
                     f"api_ready={'yes' if api_ready else 'no'}",
                     f"gh={'yes' if gh_status.get('installed') else 'no'}",
                     f"gh_auth={'yes' if gh_status.get('authenticated') else 'no'}",
@@ -1783,6 +1826,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Check .env, API key, gh auth, and Jules CLI readiness in one command.",
     )
     doctor_parser.add_argument("--compact", action="store_true", help="Print a short status line instead of JSON.")
+    doctor_parser.add_argument(
+        "--validate-api",
+        action="store_true",
+        help="Probe the Jules API to verify that the current API key can authenticate.",
+    )
     doctor_parser.set_defaults(func=doctor)
 
     gh_auth_check_parser = subparsers.add_parser(

--- a/google-jules-control/scripts/jules_api.py
+++ b/google-jules-control/scripts/jules_api.py
@@ -29,6 +29,7 @@ TERMINAL_STATES = {"FAILED", "COMPLETED"}
 OPEN_STATES = ACTIVE_STATES | WAITING_STATES
 PR_URL_RE = re.compile(r"https://github\.com/[^/\s]+/[^/\s]+/pull/\d+")
 CLOSE_CONFIRM_TOKEN = "CLOSE_MERGED_SESSION"
+DELETE_CONFIRM_TOKEN = "DELETE_JULES_SESSION"
 SUCCESSFUL_CHECK_CONCLUSIONS = {"SUCCESS", "NEUTRAL", "SKIPPED"}
 FAILED_CHECK_CONCLUSIONS = {"FAILURE", "TIMED_OUT", "CANCELLED", "STARTUP_FAILURE", "ACTION_REQUIRED", "STALE"}
 PENDING_CHECK_STATUSES = {"EXPECTED", "IN_PROGRESS", "PENDING", "QUEUED", "REQUESTED", "WAITING"}
@@ -1081,6 +1082,11 @@ def list_sessions(args: argparse.Namespace) -> None:
 
 def delete_session(args: argparse.Namespace) -> None:
     session_name = normalize_session_name(args.session)
+    if args.confirm_delete != DELETE_CONFIRM_TOKEN:
+        fail(
+            "Session deletion is irreversible and is not a pause. "
+            f"Re-run with --confirm-delete {DELETE_CONFIRM_TOKEN} after explicit user approval."
+        )
     api_request("DELETE", f"/{session_name}")
     print(json.dumps({"ok": True, "deleted": session_name}, ensure_ascii=False))
 
@@ -1861,6 +1867,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     delete_session_parser = subparsers.add_parser("delete-session", help="Delete a Jules session.")
     delete_session_parser.add_argument("--session", required=True, help="Session id or sessions/<id> resource name.")
+    delete_session_parser.add_argument(
+        "--confirm-delete",
+        help=f"Required safety token. Must be exactly {DELETE_CONFIRM_TOKEN}.",
+    )
     delete_session_parser.set_defaults(func=delete_session)
 
     cancel_session_parser = subparsers.add_parser(
@@ -1868,6 +1878,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="Delete a Jules session as a cancel-style action. This is permanent.",
     )
     cancel_session_parser.add_argument("--session", required=True, help="Session id or sessions/<id> resource name.")
+    cancel_session_parser.add_argument(
+        "--confirm-delete",
+        help=f"Required safety token. Must be exactly {DELETE_CONFIRM_TOKEN}.",
+    )
     cancel_session_parser.set_defaults(func=delete_session)
 
     get_session_parser = subparsers.add_parser("get-session", help="Fetch one Jules session.")

--- a/tests/test_jules_api.py
+++ b/tests/test_jules_api.py
@@ -15,6 +15,47 @@ SPEC.loader.exec_module(jules_api)
 
 
 class JulesApiTests(unittest.TestCase):
+    class _FakeResponse:
+        def __init__(self, body: str) -> None:
+            self.body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return self.body.encode("utf-8")
+
+    def test_build_url_uses_current_env_base_url(self) -> None:
+        with mock.patch.dict(jules_api.os.environ, {"JULES_API_BASE_URL": "https://example.test/v9"}):
+            url = jules_api.build_url("/sources", {"pageSize": 1})
+
+        self.assertEqual("https://example.test/v9/sources?pageSize=1", url)
+
+    def test_api_request_uses_request_timeout(self) -> None:
+        with mock.patch.dict(jules_api.os.environ, {"JULES_API_KEY": "test-key"}, clear=False):
+            with mock.patch.object(jules_api.urllib.request, "urlopen", return_value=self._FakeResponse("{}")) as urlopen:
+                jules_api.api_request("GET", "/sources")
+
+        self.assertEqual(60, urlopen.call_args.kwargs.get("timeout"))
+
+    def test_api_request_reports_invalid_json_without_traceback(self) -> None:
+        captured: BaseException | None = None
+        stderr = io.StringIO()
+
+        with mock.patch.dict(jules_api.os.environ, {"JULES_API_KEY": "test-key"}, clear=False):
+            with mock.patch.object(jules_api.urllib.request, "urlopen", return_value=self._FakeResponse("not json")):
+                with redirect_stderr(stderr):
+                    try:
+                        jules_api.api_request("GET", "/sources")
+                    except BaseException as exc:
+                        captured = exc
+
+        self.assertIsInstance(captured, SystemExit)
+        self.assertIn("non-JSON", stderr.getvalue())
+
     def test_build_strict_scope_prompt_includes_default_guards(self) -> None:
         prompt = jules_api.build_strict_scope_prompt("Fix the flaky login redirect test.")
 
@@ -124,6 +165,30 @@ class JulesApiTests(unittest.TestCase):
         self.assertIn("Only make the minimum changes required to make the current pull request merge-ready.", payload["prompt"])
         self.assertIn("Avoid dependency updates.", payload["prompt"])
 
+    def test_request_pr_rework_reports_missing_pull_request_output(self) -> None:
+        args = argparse.Namespace(
+            session="123",
+            extra_instruction=None,
+            send=False,
+            markdown=False,
+        )
+        session = {"name": "sessions/123", "title": "No PR", "state": "COMPLETED", "outputs": []}
+        report = {
+            "hasPullRequest": False,
+            "pullRequests": [],
+            "mergedPullRequests": [],
+            "allMerged": False,
+        }
+        stderr = io.StringIO()
+
+        with mock.patch.object(jules_api, "api_request", return_value=session):
+            with mock.patch.object(jules_api, "build_merge_report", return_value=report):
+                with redirect_stderr(stderr):
+                    with self.assertRaises(SystemExit):
+                        jules_api.request_pr_rework(args)
+
+        self.assertIn("No pull request URL", stderr.getvalue())
+
     def test_build_parser_supports_scope_control_flags(self) -> None:
         parser = jules_api.build_parser()
 
@@ -162,6 +227,36 @@ class JulesApiTests(unittest.TestCase):
         summary = jules_api.summarize_pr_merge_readiness(pr)
         self.assertFalse(summary["ready"])
         self.assertIn("ci/test=IN_PROGRESS", summary["blockers"])
+
+    def test_state_only_failed_status_check_is_not_merge_ready(self) -> None:
+        pr = {
+            "status": "not_merged",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+            "reviewDecision": None,
+            "statusCheckRollup": [{"context": "ci/legacy", "state": "FAILURE"}],
+        }
+
+        self.assertFalse(jules_api.is_pr_merge_ready(pr))
+
+        summary = jules_api.summarize_pr_merge_readiness(pr)
+        self.assertFalse(summary["ready"])
+        self.assertIn("ci/legacy=FAILURE", summary["blockers"])
+
+    def test_unknown_status_check_shape_is_not_merge_ready(self) -> None:
+        pr = {
+            "status": "not_merged",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+            "reviewDecision": None,
+            "statusCheckRollup": [{"name": "ci/unknown"}],
+        }
+
+        self.assertFalse(jules_api.is_pr_merge_ready(pr))
+
+        summary = jules_api.summarize_pr_merge_readiness(pr)
+        self.assertFalse(summary["ready"])
+        self.assertIn("ci/unknown=UNKNOWN", summary["blockers"])
 
     def test_merged_pr_readiness_has_no_spurious_blockers(self) -> None:
         pr = {

--- a/tests/test_jules_api.py
+++ b/tests/test_jules_api.py
@@ -334,8 +334,8 @@ class JulesApiTests(unittest.TestCase):
 
         self.assertEqual(1, api_request.call_count)
 
-    def test_doctor_reports_api_ready_without_merge_ready(self) -> None:
-        args = argparse.Namespace(compact=True)
+    def test_doctor_reports_api_key_present_without_api_ready_when_not_validated(self) -> None:
+        args = argparse.Namespace(compact=True, validate_api=False)
         output = io.StringIO()
 
         with mock.patch.object(jules_api, "find_dotenv_path", return_value=Path("/tmp/.env")):
@@ -350,10 +350,64 @@ class JulesApiTests(unittest.TestCase):
                             jules_api.doctor(args)
 
         rendered = output.getvalue().strip()
-        self.assertIn("api_ready=yes", rendered)
+        self.assertIn("api_key=yes", rendered)
+        self.assertIn("api_validated=no", rendered)
+        self.assertIn("api_ready=no", rendered)
         self.assertIn("cli_ready=no", rendered)
         self.assertIn("merge_ready=no", rendered)
+        self.assertIn("ready=no", rendered)
+
+    def test_doctor_validate_api_marks_api_ready_after_successful_probe(self) -> None:
+        args = argparse.Namespace(compact=True, validate_api=True)
+        output = io.StringIO()
+
+        with mock.patch.object(jules_api, "find_dotenv_path", return_value=Path("/tmp/.env")):
+            with mock.patch.dict(jules_api.os.environ, {"JULES_API_KEY": "test-key"}, clear=False):
+                with mock.patch.object(jules_api, "collect_gh_auth_status", return_value={"installed": True, "authenticated": False}):
+                    with mock.patch.object(
+                        jules_api,
+                        "collect_jules_cli_status",
+                        return_value={"installed": False, "path": None, "authStatus": "not_installed", "ready": False},
+                    ):
+                        with mock.patch.object(jules_api, "api_request", return_value={"sources": []}) as api_request:
+                            with redirect_stdout(output):
+                                jules_api.doctor(args)
+
+        api_request.assert_called_once_with("GET", "/sources", query={"pageSize": 1})
+        rendered = output.getvalue().strip()
+        self.assertIn("api_validated=yes", rendered)
+        self.assertIn("api_status=ok", rendered)
+        self.assertIn("api_ready=yes", rendered)
         self.assertIn("ready=yes", rendered)
+
+    def test_doctor_validate_api_reports_failed_probe_without_ready(self) -> None:
+        args = argparse.Namespace(compact=True, validate_api=True)
+        output = io.StringIO()
+
+        with mock.patch.object(jules_api, "find_dotenv_path", return_value=Path("/tmp/.env")):
+            with mock.patch.dict(jules_api.os.environ, {"JULES_API_KEY": "test-key"}, clear=False):
+                with mock.patch.object(jules_api, "collect_gh_auth_status", return_value={"installed": True, "authenticated": False}):
+                    with mock.patch.object(
+                        jules_api,
+                        "collect_jules_cli_status",
+                        return_value={"installed": False, "path": None, "authStatus": "not_installed", "ready": False},
+                    ):
+                        with mock.patch.object(jules_api, "api_request", side_effect=SystemExit(1)):
+                            with redirect_stdout(output):
+                                jules_api.doctor(args)
+
+        rendered = output.getvalue().strip()
+        self.assertIn("api_validated=yes", rendered)
+        self.assertIn("api_status=failed", rendered)
+        self.assertIn("api_ready=no", rendered)
+        self.assertIn("ready=no", rendered)
+
+    def test_doctor_parser_supports_api_validation_probe(self) -> None:
+        parser = jules_api.build_parser()
+
+        args = parser.parse_args(["doctor", "--validate-api"])
+
+        self.assertTrue(args.validate_api)
 
     def test_collect_jules_cli_status_marks_authenticated_when_probe_succeeds(self) -> None:
         version_result = mock.Mock(stdout="1.2.3\n", stderr="")

--- a/tests/test_jules_api.py
+++ b/tests/test_jules_api.py
@@ -334,6 +334,41 @@ class JulesApiTests(unittest.TestCase):
 
         self.assertEqual(1, api_request.call_count)
 
+    def test_delete_session_requires_explicit_confirmation_token(self) -> None:
+        args = argparse.Namespace(session="sessions/123", confirm_delete=None)
+
+        with mock.patch.object(jules_api, "api_request") as api_request:
+            with redirect_stderr(io.StringIO()) as stderr:
+                with self.assertRaises(SystemExit):
+                    jules_api.delete_session(args)
+
+        self.assertEqual(0, api_request.call_count)
+        self.assertIn("DELETE_JULES_SESSION", stderr.getvalue())
+
+    def test_delete_session_allows_explicit_confirmation_token(self) -> None:
+        args = argparse.Namespace(session="sessions/123", confirm_delete="DELETE_JULES_SESSION")
+
+        with mock.patch.object(jules_api, "api_request", return_value={}) as api_request:
+            with redirect_stdout(io.StringIO()):
+                jules_api.delete_session(args)
+
+        api_request.assert_called_once_with("DELETE", "/sessions/123")
+
+    def test_delete_session_parser_accepts_confirmation_token(self) -> None:
+        parser = jules_api.build_parser()
+
+        args = parser.parse_args(
+            [
+                "delete-session",
+                "--session",
+                "sessions/123",
+                "--confirm-delete",
+                "DELETE_JULES_SESSION",
+            ]
+        )
+
+        self.assertEqual("DELETE_JULES_SESSION", args.confirm_delete)
+
     def test_doctor_reports_api_key_present_without_api_ready_when_not_validated(self) -> None:
         args = argparse.Namespace(compact=True, validate_api=False)
         output = io.StringIO()


### PR DESCRIPTION
## Summary
- Consolidate the seven stale draft PRs #16 through #22 into one verified branch.
- Preserve the API hardening, doctor readiness split, destructive-action confirmation, plan approval review guidance, onboarding smoke test, branch/PR creation docs, and runnable release/platform guide updates.
- Resolve the integration conflicts that appeared when applying those drafts together, mainly in tests and overlapping operational docs.

## Draft PR disposition
Supersedes #16, #17, #18, #19, #20, #21, and #22.

## Verification
- `python3 -m py_compile google-jules-control/scripts/jules_api.py`
- `python3 -m unittest discover -s tests` (32 tests)
- `git diff --check origin/main..HEAD`

Closes #8
Closes #9
Closes #10
Closes #11
Closes #12
Closes #13
Closes #14
Closes #15
Closes #23